### PR TITLE
Fix README bug with encoding="utf-8"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 import sys
 import os
+import io
 
 try:
     from numpy.distutils.core import Extension, setup
@@ -13,7 +14,7 @@ f_compile_args = ['-ffixed-form', '-fdefault-real-8']
 
 
 def read(fname):
-    with open(os.path.join(os.path.dirname(__file__), fname)) as _in:
+    with io.open(os.path.join(os.path.dirname(__file__),fname), encoding="utf-8") as _in:
         return _in.read()
 
 


### PR DESCRIPTION
This change fix the compilation bug of encoding="utf-8" in the section that
reads the README. Is possible to face this bug if LANG=C is set

Signed-off-by: Victor Rodriguez <victor.rodriguez.bahena@intel.com>