### PR TITLE
BUG Fix import path for UndefinedMetricWarning

### DIFF
--- a/glmnet/util.py
+++ b/glmnet/util.py
@@ -6,8 +6,7 @@ import numpy as np
 from scipy.interpolate import interp1d
 
 from sklearn.base import clone
-# this will change to sklearn.exceptions in 0.18
-from sklearn.metrics.base import UndefinedMetricWarning
+from sklearn.exceptions import UndefinedMetricWarning
 from sklearn.model_selection import check_cv
 from sklearn.externals.joblib import Parallel, delayed
 


### PR DESCRIPTION
In scikit-learn v0.18, the `UndefinedMetricWarning` moved to the `sklearn.exceptions` module. We alredy require version >=0.18 since we use the `model_selection` module, so no need to keep the old import path.