### PR TITLE
ENH: Surface more errors from the glmnet solver

### DIFF
--- a/glmnet/errors.py
+++ b/glmnet/errors.py
@@ -2,9 +2,15 @@ import warnings
 
 
 def _check_glmnet_error_flag(jerr, n_lambda):
-    """Check the error flag. Issue warning on convergence errors (jerr < 0)
-    and exception on anything else."""
+    """Check the glmnet solver error flag and issue warnings or raise
+    exceptions as appropriate.
 
+    The codes break down roughly as follows:
+
+        jerr == 0: everything is fine
+        jerr > 0: fatal errors such as memory allocation problems
+        jerr < 0: non-fatal errors such as convergence warnings
+    """
     if jerr == 0:
         return
 

--- a/glmnet/errors.py
+++ b/glmnet/errors.py
@@ -1,0 +1,43 @@
+import warnings
+
+
+def _check_glmnet_error_flag(jerr, n_lambda):
+    """Check the error flag. Issue warning on convergence errors (jerr < 0)
+    and exception on anything else."""
+
+    if jerr == 0:
+        return
+
+    if jerr > 0:
+        _fatal_errors(jerr, n_lambda)
+
+    if jerr < 0:
+        _convergence_errors(jerr, n_lambda)
+
+
+def _fatal_errors(jerr, n_lambda):
+    if jerr == 7777:
+        raise ValueError("All predictors have zero variance "
+                         "(glmnet error no. 7777).")
+
+    if jerr == 10000:
+        raise ValueError("At least one value of relative_penalties must be "
+                         "positive (glmnet error no. 10000).")
+
+    if jerr < 7777:
+        raise RuntimeError("Memory allocation error (glmnet error no. {})."
+                           .format(jerr))
+
+    else:
+        raise RuntimeError("Fatal glmnet error no. {}.".format(jerr))
+
+
+def _convergence_errors(jerr, n_lambda):
+    if abs(jerr) <= n_lambda:
+        warnings.warn("Model did not converge for smaller values of lambda, "
+                      "returning solution for the largest {} values."
+                      .format(-1 * (jerr - 1)), RuntimeWarning)
+    else:
+        warnings.warn("Non-fatal glmnet error no. {}.".format(jerr),
+                      RuntimeWarning)
+

--- a/glmnet/errors.py
+++ b/glmnet/errors.py
@@ -1,7 +1,7 @@
 import warnings
 
 
-def _check_glmnet_error_flag(jerr, n_lambda):
+def _check_error_flag(jerr):
     """Check the glmnet solver error flag and issue warnings or raise
     exceptions as appropriate.
 
@@ -15,13 +15,13 @@ def _check_glmnet_error_flag(jerr, n_lambda):
         return
 
     if jerr > 0:
-        _fatal_errors(jerr, n_lambda)
+        _fatal_errors(jerr)
 
     if jerr < 0:
-        _convergence_errors(jerr, n_lambda)
+        _convergence_errors(jerr)
 
 
-def _fatal_errors(jerr, n_lambda):
+def _fatal_errors(jerr):
     if jerr == 7777:
         raise ValueError("All predictors have zero variance "
                          "(glmnet error no. 7777).")
@@ -30,20 +30,39 @@ def _fatal_errors(jerr, n_lambda):
         raise ValueError("At least one value of relative_penalties must be "
                          "positive (glmnet error no. 10000).")
 
+    if jerr == 90000:
+        raise ValueError("Solver did not converge (glmnet error no. 90000).")
+
     if jerr < 7777:
         raise RuntimeError("Memory allocation error (glmnet error no. {})."
                            .format(jerr))
+
+    if jerr > 8000 and jerr < 9000:
+        k = jerr - 8000
+        raise ValueError("Probability for class {} close to 0.".format(k))
+
+    if jerr > 9000:
+        k = jerr - 9000
+        raise ValueError("Probability for class {} close to 1.".format(k))
 
     else:
         raise RuntimeError("Fatal glmnet error no. {}.".format(jerr))
 
 
-def _convergence_errors(jerr, n_lambda):
-    if abs(jerr) <= n_lambda:
-        warnings.warn("Model did not converge for smaller values of lambda, "
-                      "returning solution for the largest {} values."
-                      .format(-1 * (jerr - 1)), RuntimeWarning)
-    else:
+def _convergence_errors(jerr):
+    if jerr < -20000:
+        k = abs(20000 + jerr)
+        warnings.warn("Predicted probability close to 0 or 1 for "
+                      "lambda no. {}.".format(k), RuntimeWarning)
+
+    if jerr > -20000 and jerr < -10000:
+        # This indicates the number of non-zero coefficients in a model
+        # exceeded a user-specified bound. We don't expose this parameter to
+        # the user, so there is not much sense in exposing the error either.
         warnings.warn("Non-fatal glmnet error no. {}.".format(jerr),
                       RuntimeWarning)
 
+    if jerr > -10000:
+        warnings.warn("Model did not converge for smaller values of lambda, "
+                      "returning solution for the largest {} values."
+                      .format(-1 * (jerr - 1)), RuntimeWarning)

--- a/glmnet/linear.py
+++ b/glmnet/linear.py
@@ -7,7 +7,7 @@ from sklearn.base import BaseEstimator
 from sklearn.metrics import r2_score
 from sklearn.utils import check_array, check_X_y
 
-from .errors import _check_glmnet_error_flag
+from .errors import _check_error_flag
 from _glmnet import elnet, spelnet, solns
 from .util import (_fix_lambda_path,
                    _check_user_lambda,
@@ -313,7 +313,7 @@ class ElasticNet(BaseEstimator):
 
         # raises RuntimeError if self.jerr_ is nonzero
         self.jerr_ = jerr
-        _check_glmnet_error_flag(self.jerr_, n_lambda)
+        _check_error_flag(self.jerr_)
 
         self.lambda_path_ = self.lambda_path_[:self.n_lambda_]
         self.lambda_path_ = _fix_lambda_path(self.lambda_path_)

--- a/glmnet/linear.py
+++ b/glmnet/linear.py
@@ -7,9 +7,9 @@ from sklearn.base import BaseEstimator
 from sklearn.metrics import r2_score
 from sklearn.utils import check_array, check_X_y
 
+from .errors import _check_glmnet_error_flag
 from _glmnet import elnet, spelnet, solns
 from .util import (_fix_lambda_path,
-                   _check_glmnet_error_flag,
                    _check_user_lambda,
                    _interpolate_model,
                    _score_lambda_path)
@@ -313,7 +313,7 @@ class ElasticNet(BaseEstimator):
 
         # raises RuntimeError if self.jerr_ is nonzero
         self.jerr_ = jerr
-        _check_glmnet_error_flag(self.jerr_)
+        _check_glmnet_error_flag(self.jerr_, n_lambda)
 
         self.lambda_path_ = self.lambda_path_[:self.n_lambda_]
         self.lambda_path_ = _fix_lambda_path(self.lambda_path_)

--- a/glmnet/logistic.py
+++ b/glmnet/logistic.py
@@ -9,7 +9,7 @@ from sklearn.metrics import accuracy_score
 from sklearn.utils import check_array, check_X_y
 from sklearn.utils.multiclass import check_classification_targets
 
-from .errors import _check_glmnet_error_flag
+from .errors import _check_error_flag
 from _glmnet import lognet, splognet, lsolns
 from .util import (_fix_lambda_path,
                    _check_user_lambda,
@@ -362,7 +362,7 @@ class LogitNet(BaseEstimator):
 
         # raises RuntimeError if self.jerr_ is nonzero
         self.jerr_ = jerr
-        _check_glmnet_error_flag(self.jerr_, n_lambda)
+        _check_error_flag(self.jerr_)
 
         # glmnet may not return the requested number of lambda values, so we
         # need to trim the trailing zeros from the returned path so

--- a/glmnet/logistic.py
+++ b/glmnet/logistic.py
@@ -9,9 +9,9 @@ from sklearn.metrics import accuracy_score
 from sklearn.utils import check_array, check_X_y
 from sklearn.utils.multiclass import check_classification_targets
 
+from .errors import _check_glmnet_error_flag
 from _glmnet import lognet, splognet, lsolns
 from .util import (_fix_lambda_path,
-                   _check_glmnet_error_flag,
                    _check_user_lambda,
                    _interpolate_model,
                    _score_lambda_path)
@@ -362,7 +362,7 @@ class LogitNet(BaseEstimator):
 
         # raises RuntimeError if self.jerr_ is nonzero
         self.jerr_ = jerr
-        _check_glmnet_error_flag(self.jerr_)
+        _check_glmnet_error_flag(self.jerr_, n_lambda)
 
         # glmnet may not return the requested number of lambda values, so we
         # need to trim the trailing zeros from the returned path so

--- a/glmnet/tests/test_errors.py
+++ b/glmnet/tests/test_errors.py
@@ -1,37 +1,58 @@
 import unittest
 
-from glmnet.errors import _check_glmnet_error_flag
+from glmnet.errors import _check_error_flag
 
 
 class TestErrors(unittest.TestCase):
 
     def test_zero_jerr(self):
         # This should not raise any warnings or exceptions.
-        _check_glmnet_error_flag(0, n_lambda=100)
+        _check_error_flag(0)
 
     def test_convergence_err(self):
         msg = ("Model did not converge for smaller values of lambda, "
                "returning solution for the largest 75 values.")
         with self.assertWarns(RuntimeWarning, msg=msg):
-            _check_glmnet_error_flag(-76, n_lambda=100)
+            _check_error_flag(-76)
 
     def test_zero_var_err(self):
         msg = "All predictors have zero variance (glmnet error no. 7777)."
         with self.assertRaises(ValueError, msg=msg):
-            _check_glmnet_error_flag(7777, n_lambda=100)
+            _check_error_flag(7777)
 
     def test_all_negative_rel_penalty(self):
         msg = ("At least one value of relative_penalties must be positive, "
                "(glmnet error no. 10000).")
         with self.assertRaises(ValueError, msg=msg):
-            _check_glmnet_error_flag(10000, n_lambda=100)
+            _check_error_flag(10000)
 
     def test_memory_allocation_err(self):
         msg = "Memory allocation error (glmnet error no. 1234)."
         with self.assertRaises(RuntimeError, msg=msg):
-            _check_glmnet_error_flag(1234, n_lambda=100)
+            _check_error_flag(1234)
 
     def test_other_fatal_err(self):
-        msg = "Fatal glmnet error no. 8888."
+        msg = "Fatal glmnet error no. 7778."
         with self.assertRaises(RuntimeError, msg=msg):
-            _check_glmnet_error_flag(8888, msg)
+            _check_error_flag(7778)
+
+    def test_class_prob_close_to_1(self):
+        msg = "Probability for class 2 close to 0."
+        with self.assertRaises(ValueError, msg=msg):
+            _check_error_flag(8002)
+
+    def test_class_prob_close_to_0(self):
+        msg = "Probability for class 4 close to 0."
+        with self.assertRaises(ValueError, msg=msg):
+            _check_error_flag(8004)
+
+    def test_predicted_class_close_to_0_or_1(self):
+        msg = "Predicted probability close to 0 or 1 for lambda no. 7."
+        with self.assertWarns(RuntimeWarning, msg=msg):
+            _check_error_flag(-20007)
+
+    def test_did_not_converge(self):
+        msg = "Solver did not converge (glmnet error no. 90000)."
+        with self.assertRaises(ValueError, msg=msg):
+            _check_error_flag(90000)
+

--- a/glmnet/tests/test_errors.py
+++ b/glmnet/tests/test_errors.py
@@ -1,0 +1,37 @@
+import unittest
+
+from glmnet.errors import _check_glmnet_error_flag
+
+
+class TestErrors(unittest.TestCase):
+
+    def test_zero_jerr(self):
+        # This should not raise any warnings or exceptions.
+        _check_glmnet_error_flag(0, n_lambda=100)
+
+    def test_convergence_err(self):
+        msg = ("Model did not converge for smaller values of lambda, "
+               "returning solution for the largest 75 values.")
+        with self.assertWarns(RuntimeWarning, msg=msg):
+            _check_glmnet_error_flag(-76, n_lambda=100)
+
+    def test_zero_var_err(self):
+        msg = "All predictors have zero variance (glmnet error no. 7777)."
+        with self.assertRaises(ValueError, msg=msg):
+            _check_glmnet_error_flag(7777, n_lambda=100)
+
+    def test_all_negative_rel_penalty(self):
+        msg = ("At least one value of relative_penalties must be positive, "
+               "(glmnet error no. 10000).")
+        with self.assertRaises(ValueError, msg=msg):
+            _check_glmnet_error_flag(10000, n_lambda=100)
+
+    def test_memory_allocation_err(self):
+        msg = "Memory allocation error (glmnet error no. 1234)."
+        with self.assertRaises(RuntimeError, msg=msg):
+            _check_glmnet_error_flag(1234, n_lambda=100)
+
+    def test_other_fatal_err(self):
+        msg = "Fatal glmnet error no. 8888."
+        with self.assertRaises(RuntimeError, msg=msg):
+            _check_glmnet_error_flag(8888, msg)

--- a/glmnet/tests/test_linear.py
+++ b/glmnet/tests/test_linear.py
@@ -63,6 +63,15 @@ class TestElasticNet(unittest.TestCase):
         m = m.fit(x, y)
         self.check_r2_score(y, m.predict(x), 0.90)
 
+    def test_with_no_predictor_variance(self):
+        x = np.ones((500, 1))
+        y = np.random.rand(500)
+
+        m = ElasticNet(random_state=561)
+        msg = "All predictors have zero variance (glmnet error no. 7777)."
+        with self.assertRaises(ValueError, msg=msg):
+            m.fit(x, y)
+
     def test_relative_penalties(self):
         m1 = ElasticNet(random_state=4328)
         m2 = ElasticNet(random_state=4328)
@@ -84,7 +93,7 @@ class TestElasticNet(unittest.TestCase):
 
             # verify that the unpenalized coef ests exceed the penalized ones
             # in absolute value
-            assert(np.all(np.abs(m1.coef_) <= np.abs(m2.coef_)))            
+            assert(np.all(np.abs(m1.coef_) <= np.abs(m2.coef_)))
 
     def test_alphas(self):
         x, y = self.inputs[0]

--- a/glmnet/util.py
+++ b/glmnet/util.py
@@ -126,20 +126,6 @@ def _fix_lambda_path(lambda_path):
     return lambda_path
 
 
-def _check_glmnet_error_flag(jerr):
-    """Check the error flag. Issue warning on convergence errors (jerr < 0)
-    and exception on anything else."""
-
-    if jerr and jerr != 0:
-        if jerr < 0:
-            import warnings
-            msg = "glmnet did not converge for some values of lambda {}"
-            warnings.warn(msg.format(jerr), RuntimeWarning)
-        else:
-            msg = "glmnet error no. {}"
-            raise RuntimeError(msg.format(jerr))
-
-
 def _check_user_lambda(lambda_path, lambda_best=None, lamb=None):
     """Verify the user-provided value of lambda is acceptable and ensure this
     is a 1-d array.


### PR DESCRIPTION
The glmnet solver uses integer codes to communicate errors and warnings. The error code returned by then solver is saved to the attribute `jerr` after fitting a model. Negative values denote warnings such as convergence issues, positive values denote fatal conditions such as memory allocation problems, and a value of zero is used when the solver runs successfully without error.

Initially we translated the convergence warnings into more complete messages from the numeric code. For all other errors, we just returned something opaque like "glmnet error no. 123."

In this PR, we add some additional messages and raise the relevant type of warning or exception.