### PR TITLE
BUG Satisfy scikit-learn Estimator checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 * [#44] (https://github.com/civisanalytics/python-glmnet/pull/44) Change CircleCI configuration file from v1 to v2, switch to pytest, and test in Python versions 3.4 - 3.7.
 
+### Fixed
+* [#51](https://github.com/civisanalytics/python-glmnet/pull/51)
+  Satisfy scikit-learn estimator checks. Includes
+  Allow one-sample predictions; allow list inputs for sample weights;
+  Ensure scikit-learn Estimator compatibility.
+
 ## 2.0.0 - 2017-03-01
 
 ### API Changes

--- a/glmnet/linear.py
+++ b/glmnet/linear.py
@@ -45,9 +45,9 @@ class ElasticNet(BaseEstimator):
         of standardize.
 
     lower_limits : array, (shape n_features,) default -infinity
-        Array of lower limits for each coefficient, must be non-positive.    
+        Array of lower limits for each coefficient, must be non-positive.
         Can be a single value (which is then replicated), else an array
-        corresponding to the number of features.    
+        corresponding to the number of features.
 
     upper_limits : array, (shape n_features,) default +infinity
         Array of upper limits for each coefficient, must be positive.
@@ -158,7 +158,6 @@ class ElasticNet(BaseEstimator):
         self.random_state = random_state
         self.max_features = max_features
         self.verbose = verbose
-        self.cv = None
 
     def fit(self, X, y, sample_weight=None, relative_penalties=None):
         """Fit the model to training data. If n_splits > 1 also run n-fold cross
@@ -199,16 +198,16 @@ class ElasticNet(BaseEstimator):
 
         X, y = check_X_y(X, y, accept_sparse='csr', ensure_min_samples=2)
         if sample_weight is None:
-            sample_weight = np.ones(X.shape[0])  
-                  
+            sample_weight = np.ones(X.shape[0])
+
         if not np.isscalar(self.lower_limits):
             self.lower_limits = np.asarray(self.lower_limits)
-            if len(self.lower_limits) != X.shape[1]: 
+            if len(self.lower_limits) != X.shape[1]:
                 raise ValueError("lower_limits must equal number of features")
 
         if not np.isscalar(self.upper_limits):
             self.upper_limits = np.asarray(self.upper_limits)
-            if len(self.upper_limits) != X.shape[1]: 
+            if len(self.upper_limits) != X.shape[1]:
                 raise ValueError("upper_limits must equal number of features")
 
         if any(self.lower_limits > 0) if isinstance(self.lower_limits, np.ndarray) else self.lower_limits > 0:
@@ -226,8 +225,8 @@ class ElasticNet(BaseEstimator):
         self._fit(X, y, sample_weight, relative_penalties)
 
         if self.n_splits >= 3:
-            self.cv = self.CV(n_splits=self.n_splits, shuffle=True,
-                              random_state=self.random_state)
+            self._cv = self.CV(n_splits=self.n_splits, shuffle=True,
+                               random_state=self.random_state)
 
             cv_scores = _score_lambda_path(self, X, y, sample_weight,
                                            relative_penalties,

--- a/glmnet/linear.py
+++ b/glmnet/linear.py
@@ -199,6 +199,8 @@ class ElasticNet(BaseEstimator):
         X, y = check_X_y(X, y, accept_sparse='csr', ensure_min_samples=2)
         if sample_weight is None:
             sample_weight = np.ones(X.shape[0])
+        else:
+            sample_weight = np.asarray(sample_weight)
 
         if not np.isscalar(self.lower_limits):
             self.lower_limits = np.asarray(self.lower_limits)

--- a/glmnet/logistic.py
+++ b/glmnet/logistic.py
@@ -48,7 +48,7 @@ class LogitNet(BaseEstimator):
 
     fit_intercept : bool, default True
         Include an intercept term in the model.
-    
+
     lower_limits : array, (shape n_features,) default -infinity
         Array of lower limits for each coefficient, must be non-positive.
         Can be a single value (which is then replicated), else an array
@@ -56,7 +56,7 @@ class LogitNet(BaseEstimator):
 
     upper_limits : array, (shape n_features,) default +infinity
         Array of upper limits for each coefficient, must be positive.
-        See lower_limits.		
+        See lower_limits.
 
     cut_point : float, default 1
         The cut point to use for selecting lambda_best.
@@ -163,7 +163,6 @@ class LogitNet(BaseEstimator):
         self.random_state = random_state
         self.max_features = max_features
         self.verbose = verbose
-        self.cv = None
 
     def fit(self, X, y, sample_weight=None, relative_penalties=None):
         """Fit the model to training data. If n_splits > 1 also run n-fold cross
@@ -203,16 +202,16 @@ class LogitNet(BaseEstimator):
         """
         X, y = check_X_y(X, y, accept_sparse='csr', ensure_min_samples=2)
         if sample_weight is None:
-            sample_weight = np.ones(X.shape[0])        
+            sample_weight = np.ones(X.shape[0])
 
         if not np.isscalar(self.lower_limits):
             self.lower_limits = np.asarray(self.lower_limits)
-            if len(self.lower_limits) != X.shape[1]: 
+            if len(self.lower_limits) != X.shape[1]:
                 raise ValueError("lower_limits must equal number of features")
 
         if not np.isscalar(self.upper_limits):
             self.upper_limits = np.asarray(self.upper_limits)
-            if len(self.upper_limits) != X.shape[1]: 
+            if len(self.upper_limits) != X.shape[1]:
                 raise ValueError("upper_limits must equal number of features")
 
         if any(self.lower_limits > 0) if isinstance(self.lower_limits, np.ndarray) else self.lower_limits > 0:
@@ -230,8 +229,8 @@ class LogitNet(BaseEstimator):
         # score each model on the path of lambda values found by glmnet and
         # select the best scoring
         if self.n_splits >= 3:
-            self.cv = self.CV(n_splits=self.n_splits, shuffle=True,
-                              random_state=self.random_state)
+            self._cv = self.CV(n_splits=self.n_splits, shuffle=True,
+                               random_state=self.random_state)
 
             cv_scores = _score_lambda_path(self, X, y, sample_weight,
                                            relative_penalties,
@@ -320,8 +319,8 @@ class LogitNet(BaseEstimator):
             relative_penalties = np.ones(X.shape[1], dtype=np.float64,
                                          order='F')
 
-        coef_bounds = np.empty((2, X.shape[1]), dtype=np.float64, order='F')        
-        coef_bounds[0, :] = self.lower_limits       
+        coef_bounds = np.empty((2, X.shape[1]), dtype=np.float64, order='F')
+        coef_bounds[0, :] = self.lower_limits
         coef_bounds[1, :] = self.upper_limits
 
         if n_classes == 2:

--- a/glmnet/logistic.py
+++ b/glmnet/logistic.py
@@ -203,6 +203,8 @@ class LogitNet(BaseEstimator):
         X, y = check_X_y(X, y, accept_sparse='csr', ensure_min_samples=2)
         if sample_weight is None:
             sample_weight = np.ones(X.shape[0])
+        else:
+            sample_weight = np.asarray(sample_weight)
 
         if not np.isscalar(self.lower_limits):
             self.lower_limits = np.asarray(self.lower_limits)

--- a/glmnet/logistic.py
+++ b/glmnet/logistic.py
@@ -496,7 +496,7 @@ class LogitNet(BaseEstimator):
 
         # reshape z to (n_samples, n_classes, n_lambda)
         n_lambda = len(np.atleast_1d(lamb))
-        z = z.reshape(z.shape[0], -1, n_lambda)
+        z = z.reshape(X.shape[0], -1, n_lambda)
 
         if z.shape[1] == 1:
             # binomial, for consistency and to match scikit-learn, add the

--- a/glmnet/tests/test_linear.py
+++ b/glmnet/tests/test_linear.py
@@ -14,8 +14,6 @@ from util import sanity_check_regression
 from glmnet import ElasticNet
 
 
-
-
 class TestElasticNet(unittest.TestCase):
 
     def setUp(self):
@@ -38,7 +36,7 @@ class TestElasticNet(unittest.TestCase):
             "median_absolute_error",
         ]
 
-    @ignore_warnings(RuntimeWarning)
+    @ignore_warnings(category=RuntimeWarning)
     def test_estimator_interface(self):
         estimator_checks.check_estimator(ElasticNet)
 
@@ -109,7 +107,7 @@ class TestElasticNet(unittest.TestCase):
             m = ElasticNet(lower_limits=lower_limits, upper_limits=upper_limits, random_state=5934, alpha=0)
             m = m.fit(x, y)
             assert(np.all(m.coef_ >= -1))
-            assert(np.all(m.coef_ <= 0))           
+            assert(np.all(m.coef_ <= 0))
 
     def test_n_splits(self):
         x, y = self.inputs[0]

--- a/glmnet/tests/test_linear.py
+++ b/glmnet/tests/test_linear.py
@@ -180,8 +180,8 @@ class TestElasticNet(unittest.TestCase):
         m = ElasticNet(random_state=random_state)
         x, y = self.inputs[0]
         m.fit(x, y)
-        print(dir(m.cv))
-        assert m.cv.random_state == random_state
+        print(dir(m._cv))
+        assert m._cv.random_state == random_state
 
     def test_max_features(self):
         x, y = self.inputs[3]

--- a/glmnet/tests/test_logistic.py
+++ b/glmnet/tests/test_logistic.py
@@ -83,6 +83,14 @@ class TestLogitNet(unittest.TestCase):
             p = m.predict(x, lamb=m.lambda_path_)
             assert p.shape[-1] == m.lambda_path_.size
 
+    def test_one_row_predict(self):
+        # Verify that predicting on one row gives only one row of output
+        m = LogitNet(random_state=42)
+        for X, y in itertools.chain(self.binomial, self.multinomial):
+            m.fit(X, y)
+            p = m.predict(X[0].reshape((1, -1)))
+            assert p.shape == (1,)
+
     def test_alphas(self):
         x, y = self.binomial[0]
         for alpha in self.alphas:
@@ -241,6 +249,7 @@ class TestLogitNet(unittest.TestCase):
                                 average='micro')
 
         self.assertTrue(weighted_acc >= unweighted_acc)
+
 
 def check_accuracy(y, y_hat, at_least, **other_params):
     score = accuracy_score(y, y_hat)

--- a/glmnet/tests/test_logistic.py
+++ b/glmnet/tests/test_logistic.py
@@ -66,7 +66,7 @@ class TestLogitNet(unittest.TestCase):
             "f1_weighted"
         ]
 
-    @ignore_warnings(RuntimeWarning)  # ignore convergence warnings from glmnet
+    @ignore_warnings(category=RuntimeWarning)  # convergence warnings from glmnet
     def test_estimator_interface(self):
         estimator_checks.check_estimator(LogitNet)
 

--- a/glmnet/tests/test_logistic.py
+++ b/glmnet/tests/test_logistic.py
@@ -208,8 +208,8 @@ class TestLogitNet(unittest.TestCase):
         m = LogitNet(random_state=random_state)
         x, y = self.binomial[0]
         m.fit(x, y)
-        print(dir(m.cv))
-        assert m.cv.random_state == random_state
+        print(dir(m._cv))
+        assert m._cv.random_state == random_state
 
     def test_max_features(self):
         max_features = 5

--- a/glmnet/util.py
+++ b/glmnet/util.py
@@ -7,7 +7,6 @@ from scipy.interpolate import interp1d
 
 from sklearn.base import clone
 from sklearn.exceptions import UndefinedMetricWarning
-from sklearn.model_selection import check_cv
 from sklearn.externals.joblib import Parallel, delayed
 
 from .scorer import check_scoring
@@ -50,7 +49,7 @@ def _score_lambda_path(est, X, y, sample_weight, relative_penalties,
         Scores for each value of lambda over all cv folds.
     """
     scorer = check_scoring(est, scoring)
-    cv_split = est.cv.split(X, y)
+    cv_split = est._cv.split(X, y)
 
     # We score the model for every value of lambda, for classification
     # models, this will be an intercept-only model, meaning it predicts


### PR DESCRIPTION
The scikit-learn `check_estimator` function appears to have become more comprehensive in the past year. Add fixes for the things that have changed. Includes
- Ensure full compatibility with scikit-learn Estimator API (fix for a change in #24)
- Allow one-row predictions (includes the fix from #26 )
- Update test function `ignore_warnings` for the new function signature
- Allow list inputs for `sample_weights`

Note that this PR does hide the previously public `cv` attribute, but that attribute was introduced in PR #24 which has not yet been released.

Closes #25 