### PR TITLE
BUG Return correct prediction dims with and without lambda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   Satisfy scikit-learn estimator checks. Includes:
   Allow one-sample predictions; allow list inputs for sample weights;
   Ensure scikit-learn Estimator compatibility.
+* [#53](https://github.com/civisanalytics/python-glmnet/pull/53)
+  Return correct dimensions for 1-row predictions, with or without lambda
+  path, in both `LogitNet` and `ElasticNet` (#52, #30, #25).
 
 ## 2.0.0 - 2017-03-01
 

--- a/glmnet/linear.py
+++ b/glmnet/linear.py
@@ -384,7 +384,9 @@ class ElasticNet(BaseEstimator):
 
         # drop last dimension (lambda path) when we are predicting for a
         # single value of lambda
-        return z.squeeze()
+        if lamb.shape[0] == 1:
+            z = z.squeeze(axis=-1)
+        return z
 
     def predict(self, X, lamb=None):
         """Predict the response Y for each sample in X

--- a/glmnet/logistic.py
+++ b/glmnet/logistic.py
@@ -505,7 +505,10 @@ class LogitNet(BaseEstimator):
         else:
             # normalize for multinomial
             z /= np.expand_dims(z.sum(axis=1), axis=1)
-        return np.atleast_2d(z.squeeze())
+
+        if n_lambda == 1:
+            z = z.squeeze(axis=-1)
+        return z
 
     def predict(self, X, lamb=None):
         """Predict class labels for samples in X.

--- a/glmnet/tests/test_linear.py
+++ b/glmnet/tests/test_linear.py
@@ -53,6 +53,22 @@ class TestElasticNet(unittest.TestCase):
             p = m.predict(x, lamb=m.lambda_path_)
             self.assertEqual(p.shape[-1], m.lambda_path_.size)
 
+    def test_one_row_predict(self):
+        # Verify that predicting on one row gives only one row of output
+        m = ElasticNet(random_state=42)
+        for X, y in self.inputs:
+            m.fit(X, y)
+            p = m.predict(X[0].reshape((1, -1)))
+            assert p.shape == (1,)
+
+    def test_one_row_predict_with_lambda(self):
+        # One row to predict along with lambdas should give 2D output
+        m = ElasticNet(random_state=42)
+        for X, y in self.inputs:
+            m.fit(X, y)
+            p = m.predict(X[0].reshape((1, -1)), lamb=[20, 10])
+            assert p.shape == (1, 2)
+
     def test_with_single_var(self):
         x = np.random.rand(500,1)
         y = (1.3 * x).ravel()

--- a/glmnet/tests/test_logistic.py
+++ b/glmnet/tests/test_logistic.py
@@ -26,7 +26,7 @@ class TestLogitNet(unittest.TestCase):
         x_wide, y_wide = make_classification(n_samples=100, n_features=150,
                                              random_state=8911)
         x_wide_sparse = csr_matrix(x_wide)
-        self.binomial = [(x,y), (x_sparse, y), (x_wide, y_wide),
+        self.binomial = [(x, y), (x_sparse, y), (x_wide, y_wide),
                          (x_wide_sparse, y_wide)]
 
         # multinomial
@@ -90,6 +90,32 @@ class TestLogitNet(unittest.TestCase):
             m.fit(X, y)
             p = m.predict(X[0].reshape((1, -1)))
             assert p.shape == (1,)
+
+    def test_one_row_predict_proba(self):
+        # Verify that predict_proba on one row gives 2D output
+        m = LogitNet(random_state=42)
+        for X, y in itertools.chain(self.binomial, self.multinomial):
+            m.fit(X, y)
+            p = m.predict_proba(X[0].reshape((1, -1)))
+            assert p.shape == (1, len(np.unique(y)))
+
+    def test_one_row_predict_with_lambda(self):
+        # One row to predict along with lambdas should give 2D output
+        m = LogitNet(random_state=42)
+        lamb = [0.01, 0.02, 0.04, 0.1]
+        for X, y in itertools.chain(self.binomial, self.multinomial):
+            m.fit(X, y)
+            p = m.predict(X[0].reshape((1, -1)), lamb=lamb)
+            assert p.shape == (1, len(lamb))
+
+    def test_one_row_predict_proba_with_lambda(self):
+        # One row to predict_proba along with lambdas should give 3D output
+        m = LogitNet(random_state=42)
+        lamb = [0.01, 0.02, 0.04, 0.1]
+        for X, y in itertools.chain(self.binomial, self.multinomial):
+            m.fit(X, y)
+            p = m.predict_proba(X[0].reshape((1, -1)), lamb=lamb)
+            assert p.shape == (1, len(np.unique(y)), len(lamb))
 
     def test_alphas(self):
         x, y = self.binomial[0]


### PR DESCRIPTION
Instead of trying for a one-liner with magic `squeeze` behavior, only squeeze if predicting for a single lambda value, and then only squeeze off the last axis (the lambda path). This way we'll get the correct return shape for all input shapes, including single rows.

PR #51 fixed 1-row predictions for the case of single-lambda predictions with `LogitNet`, but didn't properly handle multi-lambda predictions, and didn't fix 1-row predictions for `ElasticNet`.

Closes #52 , #30 , #25 .