### PR TITLE
DOC Mark Fortran code as linguist-vendored

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 glmnet/_version.py export-subst
+glmnet/src/glmnet/* linguist-vendored

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Changed
+* [#57](https://github.com/civisanalytics/python-glmnet/pull/57)
+  Mark the Fortran code as linguist-vendored so that GitHub classifies
+  this project as Python (#37).
+
 ## 2.1.1 - 2019-03-11
 ### Fixed
 * [#55](https://github.com/civisanalytics/python-glmnet/pull/55)


### PR DESCRIPTION
GitHub's linguist library sees the glmnet Fortran code and marks this repository as a Fortran project. It would be better to have it display as Python. Tell `linguist` that the Fortran code is vendored so that it will be ignored in summary statistics.

See https://github.com/github/linguist#vendored-code

Partially addresses #37 .