### PR TITLE
Remove try-catch numpy requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,13 +4,6 @@ import io
 import setuptools
 from setuptools import setup
 
-try:
-    from numpy.distutils.core import Extension, setup
-except ImportError:
-    sys.exit("install requires: 'numpy'."
-             " use pip or easy_install."
-             " \n  $ pip install numpy")
-
 
 f_compile_args = ['-ffixed-form', '-fdefault-real-8']
 


### PR DESCRIPTION
The install_requires kwarg in setup() should already cover this case.
These lines are breaking install via pip with a requirements file, as there's no way to guarantee numpy is already installed before this setup.py is called.