### PR TITLE
Update the cross-validation to be able to use user-inputted groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 * [#57](https://github.com/civisanalytics/python-glmnet/pull/57)
   Mark the Fortran code as linguist-vendored so that GitHub classifies
   this project as Python (#37).
+* [#62](https://github.com/civisanalytics/python-glmnet/pull/62)
+  Update the cross-validation for users to be able to define groups of
+  observations, which is equivalent with *foldid* of *cvglmnet* in *R*.
 
 ## 2.1.1 - 2019-03-11
 ### Fixed

--- a/glmnet/linear.py
+++ b/glmnet/linear.py
@@ -157,7 +157,7 @@ class ElasticNet(BaseEstimator):
         self.max_features = max_features
         self.verbose = verbose
 
-    def fit(self, X, y, groups=None, sample_weight=None, relative_penalties=None):
+    def fit(self, X, y, sample_weight=None, relative_penalties=None, groups=None):
         """Fit the model to training data. If n_splits > 1 also run n-fold cross
         validation on all values in lambda_path.
 
@@ -181,15 +181,17 @@ class ElasticNet(BaseEstimator):
         y : array, shape (n_samples,)
             Target values
 
-        groups: array, shape (n_samples,)
-            Group labels for the samples used while splitting the dataset into train/test set.
-
         sample_weight : array, shape (n_samples,)
             Optional weight vector for observations
 
         relative_penalties: array, shape (n_features,)
             Optional relative weight vector for penalty.
             0 entries remove penalty.
+
+        groups: array, shape (n_samples,)
+            Group labels for the samples used while splitting the dataset into train/test set.
+            If the groups are specified, the groups will be passed to sklearn.model_selection.GroupKFold.
+            If None, then data will be split randomly for K-fold cross-validation via sklearn.model_selection.KFold.
 
         Returns
         -------

--- a/glmnet/logistic.py
+++ b/glmnet/logistic.py
@@ -207,6 +207,9 @@ class LogitNet(BaseEstimator):
         else:
             sample_weight = np.asarray(sample_weight)
 
+            if y.shape != sample_weight.shape:
+                raise ValueError('the shape of weights is not the same with the shape of y')
+
         if not np.isscalar(self.lower_limits):
             self.lower_limits = np.asarray(self.lower_limits)
             if len(self.lower_limits) != X.shape[1]:

--- a/glmnet/logistic.py
+++ b/glmnet/logistic.py
@@ -162,7 +162,7 @@ class LogitNet(BaseEstimator):
         self.max_features = max_features
         self.verbose = verbose
 
-    def fit(self, X, y, groups=None, sample_weight=None, relative_penalties=None):
+    def fit(self, X, y, sample_weight=None, relative_penalties=None, groups=None):
         """Fit the model to training data. If n_splits > 1 also run n-fold cross
         validation on all values in lambda_path.
 
@@ -186,15 +186,17 @@ class LogitNet(BaseEstimator):
         y : array, shape (n_samples,)
             Target values
 
-        groups: array, shape (n_samples,)
-            Group labels for the samples used while splitting the dataset into train/test set.
-
         sample_weight : array, shape (n_samples,)
             Optional weight vector for observations
 
         relative_penalties: array, shape (n_features,)
             Optional relative weight vector for penalty.
             0 entries remove penalty.
+
+        groups: array, shape (n_samples,)
+            Group labels for the samples used while splitting the dataset into train/test set.
+            If the groups are specified, the groups will be passed to sklearn.model_selection.GroupKFold.
+            If None, then data will be split randomly for K-fold cross-validation via sklearn.model_selection.KFold.
 
         Returns
         -------

--- a/glmnet/logistic.py
+++ b/glmnet/logistic.py
@@ -6,7 +6,7 @@ from scipy import stats
 
 from sklearn.base import BaseEstimator
 from sklearn.metrics import accuracy_score
-from sklearn.model_selection import StratifiedKFold
+from sklearn.model_selection import StratifiedKFold, GroupKFold
 from sklearn.utils import check_array, check_X_y
 from sklearn.utils.multiclass import check_classification_targets
 
@@ -138,8 +138,6 @@ class LogitNet(BaseEstimator):
         performs within cut_point * standard error of lambda_max_.
     """
 
-    CV = StratifiedKFold
-
     def __init__(self, alpha=1, n_lambda=100, min_lambda_ratio=1e-4,
                  lambda_path=None, standardize=True, fit_intercept=True,
                  lower_limits=-np.inf, upper_limits=np.inf,
@@ -164,7 +162,7 @@ class LogitNet(BaseEstimator):
         self.max_features = max_features
         self.verbose = verbose
 
-    def fit(self, X, y, sample_weight=None, relative_penalties=None):
+    def fit(self, X, y, groups=None, sample_weight=None, relative_penalties=None):
         """Fit the model to training data. If n_splits > 1 also run n-fold cross
         validation on all values in lambda_path.
 
@@ -185,8 +183,11 @@ class LogitNet(BaseEstimator):
         X : array, shape (n_samples, n_features)
             Input features
 
-        Y : array, shape (n_samples,)
+        y : array, shape (n_samples,)
             Target values
+
+        groups: array, shape (n_samples,)
+            Group labels for the samples used while splitting the dataset into train/test set.
 
         sample_weight : array, shape (n_samples,)
             Optional weight vector for observations
@@ -231,10 +232,13 @@ class LogitNet(BaseEstimator):
         # score each model on the path of lambda values found by glmnet and
         # select the best scoring
         if self.n_splits >= 3:
-            self._cv = self.CV(n_splits=self.n_splits, shuffle=True,
-                               random_state=self.random_state)
+            if groups is None:
+                self._cv = StratifiedKFold(n_splits=self.n_splits, shuffle=True, random_state=self.random_state)
+            else:
+                self._cv = GroupKFold(n_splits=self.n_splits)
 
-            cv_scores = _score_lambda_path(self, X, y, sample_weight,
+            cv_scores = _score_lambda_path(self, X, y, groups,
+                                           sample_weight,
                                            relative_penalties,
                                            self.scoring,
                                            n_jobs=self.n_jobs,

--- a/glmnet/scorer.py
+++ b/glmnet/scorer.py
@@ -21,7 +21,7 @@ from sklearn.metrics import (r2_score, median_absolute_error, mean_absolute_erro
                roc_auc_score, average_precision_score,
                precision_score, recall_score, log_loss)
 from sklearn.utils.multiclass import type_of_target
-from sklearn.externals import six
+import six
 
 
 class _BaseScorer(six.with_metaclass(ABCMeta, object)):

--- a/glmnet/util.py
+++ b/glmnet/util.py
@@ -7,7 +7,7 @@ from scipy.interpolate import interp1d
 
 from sklearn.base import clone
 from sklearn.exceptions import UndefinedMetricWarning
-from sklearn.externals.joblib import Parallel, delayed
+from joblib import Parallel, delayed
 
 from .scorer import check_scoring
 

--- a/glmnet/util.py
+++ b/glmnet/util.py
@@ -12,7 +12,7 @@ from sklearn.externals.joblib import Parallel, delayed
 from .scorer import check_scoring
 
 
-def _score_lambda_path(est, X, y, sample_weight, relative_penalties,
+def _score_lambda_path(est, X, y, groups, sample_weight, relative_penalties,
                        scoring, n_jobs, verbose):
     """Score each model found by glmnet using cross validation.
 
@@ -26,6 +26,9 @@ def _score_lambda_path(est, X, y, sample_weight, relative_penalties,
 
     y : array, shape (n_samples,)
         Target values.
+
+    groups: array, shape (n_samples,)
+        Group labels for the samples used while splitting the dataset into train/test set.
 
     sample_weight : array, shape (n_samples,)
         Weight of each row in X.
@@ -49,7 +52,7 @@ def _score_lambda_path(est, X, y, sample_weight, relative_penalties,
         Scores for each value of lambda over all cv folds.
     """
     scorer = check_scoring(est, scoring)
-    cv_split = est._cv.split(X, y)
+    cv_split = est._cv.split(X, y, groups)
 
     # We score the model for every value of lambda, for classification
     # models, this will be an intercept-only model, meaning it predicts

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy>=1.9.2
 scikit-learn>=0.18.0
 scipy>=0.14.1
+joblib>=0.14.1


### PR DESCRIPTION
- Linear and logistic regressions were updated to be able to use user-inputted labels when splitting training sets for cross validation.
- The *groups* argument is equivalent to the *foldid* argument of *cvglmnet* in *R*.
- Use *joblib* and *six* modules instead of *sklearn.external*.
- Check the validity of the shape of weights in *logitnet.py*.