### PR TITLE
[PARO-779] Prep for v2.2.1 release; remove six dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## 2.2.1 - 2020-06-30
+### Fix
+* [#65](https://github.com/civisanalytics/python-glmnet/pull/65)
+  Remove `six` dependency entirely.
+
 ## 2.2.0 - 2020-06-29
 ### Changed
 * [#57](https://github.com/civisanalytics/python-glmnet/pull/57)

--- a/glmnet/linear.py
+++ b/glmnet/linear.py
@@ -10,7 +10,10 @@ from sklearn.utils import check_array, check_X_y
 
 from .errors import _check_error_flag
 from _glmnet import elnet, spelnet, solns
-from glmnet.util import _fix_lambda_path, _score_lambda_path
+from glmnet.util import (_fix_lambda_path,
+                         _check_user_lambda,
+                         _interpolate_model,
+                         _score_lambda_path)
 
 
 class ElasticNet(BaseEstimator):

--- a/glmnet/linear.py
+++ b/glmnet/linear.py
@@ -10,10 +10,7 @@ from sklearn.utils import check_array, check_X_y
 
 from .errors import _check_error_flag
 from _glmnet import elnet, spelnet, solns
-from .util import (_fix_lambda_path,
-                   _check_user_lambda,
-                   _interpolate_model,
-                   _score_lambda_path)
+from glmnet.util import _fix_lambda_path, _score_lambda_path
 
 
 class ElasticNet(BaseEstimator):

--- a/glmnet/logistic.py
+++ b/glmnet/logistic.py
@@ -12,7 +12,10 @@ from sklearn.utils.multiclass import check_classification_targets
 
 from .errors import _check_error_flag
 from _glmnet import lognet, splognet, lsolns
-from glmnet.util import _fix_lambda_path, _score_lambda_path
+from glmnet.util import (_fix_lambda_path,
+                         _check_user_lambda,
+                         _interpolate_model,
+                         _score_lambda_path)
 
 
 class LogitNet(BaseEstimator):

--- a/glmnet/logistic.py
+++ b/glmnet/logistic.py
@@ -12,10 +12,7 @@ from sklearn.utils.multiclass import check_classification_targets
 
 from .errors import _check_error_flag
 from _glmnet import lognet, splognet, lsolns
-from .util import (_fix_lambda_path,
-                   _check_user_lambda,
-                   _interpolate_model,
-                   _score_lambda_path)
+from glmnet.util import _fix_lambda_path, _score_lambda_path
 
 
 class LogitNet(BaseEstimator):

--- a/glmnet/scorer.py
+++ b/glmnet/scorer.py
@@ -21,10 +21,9 @@ from sklearn.metrics import (r2_score, median_absolute_error, mean_absolute_erro
                roc_auc_score, average_precision_score,
                precision_score, recall_score, log_loss)
 from sklearn.utils.multiclass import type_of_target
-import six
 
 
-class _BaseScorer(six.with_metaclass(ABCMeta, object)):
+class _BaseScorer(metaclass=ABCMeta):
     def __init__(self, score_func, sign, kwargs):
         self._kwargs = kwargs
         self._score_func = score_func
@@ -173,7 +172,7 @@ class _ThresholdScorer(_BaseScorer):
 
 
 def get_scorer(scoring):
-    if isinstance(scoring, six.string_types):
+    if isinstance(scoring, str):
         try:
             scorer = SCORERS[scoring]
         except KeyError:

--- a/glmnet/tests/test_linear.py
+++ b/glmnet/tests/test_linear.py
@@ -9,7 +9,7 @@ from sklearn.metrics import r2_score
 from sklearn.utils import estimator_checks
 from sklearn.utils.testing import ignore_warnings
 
-from util import sanity_check_regression
+from glmnet.tests.util import sanity_check_regression
 
 from glmnet import ElasticNet
 

--- a/glmnet/tests/test_logistic.py
+++ b/glmnet/tests/test_logistic.py
@@ -10,7 +10,7 @@ from sklearn.metrics import accuracy_score, f1_score
 from sklearn.utils import estimator_checks, class_weight
 from sklearn.utils.testing import ignore_warnings
 
-from util import sanity_check_logistic
+from glmnet.tests.util import sanity_check_logistic
 
 from glmnet import LogitNet
 

--- a/glmnet/tests/test_pandas.py
+++ b/glmnet/tests/test_pandas.py
@@ -3,7 +3,7 @@ import unittest
 from sklearn.datasets import make_regression, make_classification
 from glmnet import LogitNet, ElasticNet
 
-from util import sanity_check_logistic, sanity_check_regression
+from glmnet.tests.util import sanity_check_logistic, sanity_check_regression
 
 pd = None
 try:

--- a/glmnet/util.py
+++ b/glmnet/util.py
@@ -9,7 +9,7 @@ from sklearn.base import clone
 from sklearn.exceptions import UndefinedMetricWarning
 from joblib import Parallel, delayed
 
-from .scorer import check_scoring
+from glmnet.scorer import check_scoring
 
 
 def _score_lambda_path(est, X, y, groups, sample_weight, relative_penalties,

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ except ImportError:
              " \n  $ pip install numpy")
 
 
-_VERSION = "2.2.0"
+_VERSION = "2.2.1"
 
 f_compile_args = ['-ffixed-form', '-fdefault-real-8']
 


### PR DESCRIPTION
This PR removes the `six` dependency entirely. Since python-glmnet is python 3 only, `six` shouldn't be used anymore.

I wasn't aware `six` was still actually called until after the v2.2.0 release and while working through the conda-forge release (see https://github.com/conda-forge/glmnet-feedstock/pull/14, which I had to abandon). At https://github.com/civisanalytics/python-glmnet/pull/64, all builds passed because `six` was available via `pytest` in the build environment.