### PR TITLE
Remove z.squeeze function in linear.py

### DIFF
--- a/glmnet/linear.py
+++ b/glmnet/linear.py
@@ -390,7 +390,8 @@ class ElasticNet(BaseEstimator):
 
         # drop last dimension (lambda path) when we are predicting for a
         # single value of lambda
-        # FORK EDIT: when using lambda_path = [value] the shape already is sinle, 
+      
+        # FORK EDIT: when using lambda_path = [value] the shape already is single (meaning: (number,)),
         # therefore no need to squeeze remove last axis since it only has 1 to begin with
         # if lamb.shape[0] == 1:
         #    z = z.squeeze(axis=-1)

--- a/glmnet/linear.py
+++ b/glmnet/linear.py
@@ -390,8 +390,10 @@ class ElasticNet(BaseEstimator):
 
         # drop last dimension (lambda path) when we are predicting for a
         # single value of lambda
-        if lamb.shape[0] == 1:
-            z = z.squeeze(axis=-1)
+        # FORK EDIT: when using lambda_path = [value] the shape already is sinle, 
+        # therefore no need to squeeze remove last axis since it only has 1 to begin with
+        # if lamb.shape[0] == 1:
+        #    z = z.squeeze(axis=-1)
         return z
 
     def predict(self, X, lamb=None):


### PR DESCRIPTION
I found that when passing lambda_path = [single_value], the shape of z is already missing the last dimension, therefore it already is 1D. I know passing a single value to lambda_path is not the "correct" thing to do, but for my specific case I need to work like this. For this I removed the squeeze part and directly return z as it is.